### PR TITLE
fix : jwt token을 email 기반에서 OAuthId, type을 기반으로 변경

### DIFF
--- a/src/main/java/com/humanicare/backend/domain/RefreshToken.java
+++ b/src/main/java/com/humanicare/backend/domain/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.humanicare.backend.domain;
 
+import com.humanicare.backend.oauth.OauthServerType;
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,7 +25,11 @@ public class RefreshToken {
     @Column(name = "refresh_token_id")
     private Long id;
 
-    private String email;
+    @Indexed
+    private String oauthId;
+
+    @Indexed
+    private OauthServerType oauthServerType;
 
     @Indexed
     private String refresh;

--- a/src/main/java/com/humanicare/backend/domain/oauth/OauthId.java
+++ b/src/main/java/com/humanicare/backend/domain/oauth/OauthId.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
@@ -33,5 +35,19 @@ public class OauthId {
 
     public OauthServerType oauthServer() {
         return oauthServerType;
+    }
+
+    //respository에서 findBy를 할 때 객체 비교를 정확하게 수행할 수 있다.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OauthId that)) return false;
+        return Objects.equals(oauthServerId, that.oauthServerId)
+                && oauthServerType == that.oauthServerType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oauthServerId, oauthServerType);
     }
 }

--- a/src/main/java/com/humanicare/backend/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/humanicare/backend/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,3 +1,4 @@
+// JwtAuthenticationProcessingFilter.java
 package com.humanicare.backend.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -5,6 +6,7 @@ import com.humanicare.backend.domain.oauth.User;
 import com.humanicare.backend.exception.TokenInvalidException;
 import com.humanicare.backend.jwt.service.JwtService;
 import com.humanicare.backend.jwt.util.PasswordUtil;
+import com.humanicare.backend.oauth.OauthServerType;
 import com.humanicare.backend.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -24,13 +26,6 @@ import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-
-/**
- * Jwt 인증 필터 로그인 이외의 URI 요청이 왔을 때 처리하는 필터
- * <p>
- * AccessToken 유효성 검사를 진행하고 유효하지 않으면 프론트로 에러 메시지를 보낸다. 프론트에서 에러 메시지를 받으면 재발급 API CALL
- */
 
 @RequiredArgsConstructor
 @Slf4j
@@ -62,11 +57,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         checkAccessTokenAndAuthentication(request, response, filterChain);
     }
 
-    /**
-     * [AccessToken 체크 & 인증 처리 메소드] request에서 extractAccessToken()으로 AccessToken 추출 후, isTokenValid()로 유효한 토큰인지 검증 유효한
-     * 토큰이면, AccessToken서 extractEmail로 Email을 추출한 후 findByEmail()로 해당 이메일을 사용하는 유저 객체 반환 그 유저 객체를
-     * saveAuthentication()으로 인증 처리하여 인증 허가 처리된 객체를 SecurityContextHolder에 담기 그 후 다음 인증 필터로 진행
-     */
     public void checkAccessTokenAndAuthentication(final HttpServletRequest request, final HttpServletResponse response,
                                                   final FilterChain filterChain) throws IOException, ServletException {
         if (isSwaggerPath(request)) {
@@ -83,9 +73,17 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
         try {
             jwtService.isTokenValid(accessToken);
-            jwtService.extractEmail(accessToken)
-                    .flatMap(userRepository::findByEmail)
-                    .ifPresent(this::saveAuthentication);
+            var oauthIdOpt = jwtService.extractOauthId(accessToken);
+            var providerOpt = jwtService.extractOauthServerType(accessToken);
+
+            if (oauthIdOpt.isPresent() && providerOpt.isPresent()) {
+                userRepository.findByOauthId_OauthServerIdAndOauthId_OauthServerType(
+                        oauthIdOpt.get(), providerOpt.get()
+                ).ifPresent(this::saveAuthentication);
+            } else {
+                sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "토큰 정보가 부족합니다.");
+                return;
+            }
         } catch (TokenInvalidException e) {
             sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
             return;
@@ -96,19 +94,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * [인증 허가 메소드] 파라미터의 유저 : 우리가 만든 회원 객체 / 빌더의 유저 : UserDetails의 User 객체
-     * <p>
-     * new UsernamePasswordAuthenticationToken()로 인증 객체인 Authentication 객체 생성 UsernamePasswordAuthenticationToken의 파라미터
-     * 1. 위에서 만든 UserDetailsUser 객체 (유저 정보) 2. credential(보통 비밀번호로, 인증 시에는 보통 null로 제거) 3. Collection < ? extends
-     * GrantedAuthority>로, UserDetails의 User 객체 안에 Set<GrantedAuthority> authorities이 있어서 getter로 호출한 후에, new
-     * NullAuthoritiesMapper()로 GrantedAuthoritiesMapper 객체를 생성하고 mapAuthorities()에 담기
-     * <p>
-     * SecurityContextHolder.getContext()로 SecurityContext를 꺼낸 후, setAuthentication()을 이용하여 위에서 만든 Authentication 객체에 대한
-     * 인증 허가 처리
-     */
     public void saveAuthentication(final User user) {
-
         UserDetails userDetailsUser = getUserDetails(user);
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(userDetailsUser, null,
@@ -135,7 +121,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                 .build();
     }
 
-    // 오류 정보 {status, message}를 JSON 형태로 바꿔서 응답
     private void sendErrorResponse(final HttpServletResponse response, final int statusCode, final String message)
             throws IOException {
         response.setStatus(statusCode);

--- a/src/main/java/com/humanicare/backend/jwt/service/JwtService.java
+++ b/src/main/java/com/humanicare/backend/jwt/service/JwtService.java
@@ -1,8 +1,5 @@
 package com.humanicare.backend.jwt.service;
 
-
-import static com.humanicare.backend.constant.Constants.ACCESS_TOKEN_REPLACEMENT;
-
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -13,14 +10,13 @@ import com.humanicare.backend.apiPayload.exception.handler.AccessTokenHandler;
 import com.humanicare.backend.apiPayload.exception.handler.RefreshTokenHandler;
 import com.humanicare.backend.domain.RefreshToken;
 import com.humanicare.backend.exception.TokenInvalidException;
+import com.humanicare.backend.oauth.OauthServerType;
 import com.humanicare.backend.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Optional;
-import java.util.UUID;
+
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -35,14 +31,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class JwtService {
 
-    private static final String SUCCESS_TOKEN = "AccessToken, RefreshToken 발급 완료";
-    private static final String INVALID_ACCESS_TOKEN = "AccessToken이 유효하지 않습니다.";
-    private static final String INVALID_TOKEN = "유효하지 않은 토큰";
-    private static final String RUNTIME_ERROR_TOKEN_CHECK = "토큰 검증 중 런타임 오류 발생";
-
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
-    private static final String EMAIL_CLAIM = "email";
+    private static final String OAUTH_ID_CLAIM = "oauth_id";
+    private static final String PROVIDER_CLAIM = "provider";
     private static final String BEARER = "Bearer ";
 
     private final RedisTemplate<String, Object> redisTemplate;
@@ -59,38 +51,27 @@ public class JwtService {
     @Value("${jwt.refresh.header}")
     private String refreshHeader;
 
-    // 테스트용 토큰 생성 메서드 추가
+    /**
+     * Swagget 용 Test Token생성
+     */
     public String generateTestToken() {
-        Date now = new Date();
-        return JWT.create()
-                .withSubject(ACCESS_TOKEN_SUBJECT)
-                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
-                .withClaim("unique_id", UUID.randomUUID().toString())
-                .withClaim(EMAIL_CLAIM, "test@example.com")
-                .sign(Algorithm.HMAC512(secretKey));
+        return createAccessToken("test-oauth-id-1", OauthServerType.KAKAO);
     }
 
-    // 테스트용 토큰 생성 메서드 추가
     public String generateTest2Token() {
-        Date now = new Date();
-        return JWT.create()
-                .withSubject(ACCESS_TOKEN_SUBJECT)
-                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
-                .withClaim("unique_id", UUID.randomUUID().toString())
-                .withClaim(EMAIL_CLAIM, "test2@example.com")
-                .sign(Algorithm.HMAC512(secretKey));
+        return createAccessToken("test-oauth-id-2", OauthServerType.GOOGLE);
     }
 
     /**
-     * AccessToken 생성 메서드
+     * Oauth 기반 AccessToken 생성
      */
-    public String createAccessToken(final String email) {
+    public String createAccessToken(final String oauthId, final OauthServerType provider) {
         Date now = new Date();
         return JWT.create()
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
-                .withClaim("unique_id", UUID.randomUUID().toString())
-                .withClaim(EMAIL_CLAIM, email)
+                .withClaim(OAUTH_ID_CLAIM, oauthId)
+                .withClaim(PROVIDER_CLAIM, provider.name())
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
@@ -107,7 +88,7 @@ public class JwtService {
     }
 
     /**
-     * AccessToken을 response Header에 담기 : 발급
+     * AccessToken을 응답 헤더에 추가
      */
     public void sendAccessToken(final HttpServletResponse response, final String accessToken) {
         response.setStatus(HttpServletResponse.SC_OK);
@@ -115,25 +96,24 @@ public class JwtService {
     }
 
     /**
-     * RefreshToken을 Cookie에 담기
+     * RefreshToken을 쿠키에 추가
      */
     public void sendRefreshToken(final HttpServletResponse response, final String refreshToken) {
         response.addCookie(createCookie(refreshHeader, refreshToken));
     }
 
     /**
-     * AccessToken을 헤더에, RefreshToken을 쿠키에 담아서 보내기 - 토큰 발급
+     * AccessToken + RefreshToken 전송
      */
     public void sendAccessAndRefreshToken(final HttpServletResponse response, final String accessToken,
                                           final String refreshToken) {
         response.setStatus(HttpServletResponse.SC_OK);
         sendAccessToken(response, accessToken);
         sendRefreshToken(response, refreshToken);
-        log.info(SUCCESS_TOKEN);
     }
 
     /**
-     * Cookie에서 RefreshToken 추출하기
+     * 쿠키에서 RefreshToken 추출
      */
     public Optional<String> extractRefreshToken(final HttpServletRequest request) {
         if (request.getCookies() == null) {
@@ -149,82 +129,85 @@ public class JwtService {
     }
 
     /**
-     * Request Header에서 AccessToken 추출하기
+     * 요청 헤더에서 AccessToken 추출
      */
     public Optional<String> extractAccessToken(final HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(accessHeader))
                 .filter(accessToken -> accessToken.startsWith(BEARER))
-                .map(accessToken -> accessToken.replace(BEARER, ACCESS_TOKEN_REPLACEMENT));
+                .map(accessToken -> accessToken.substring(BEARER.length()));
     }
 
     /**
-     * AccessToken에서 email을 추출하기
+     * AccessToken에서 oauth_id 추출
      */
-    public Optional<String> extractEmail(final String accessToken) {
+    public Optional<String> extractOauthId(final String token) {
         try {
             return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                     .build()
-                    .verify(accessToken)
-                    .getClaim(EMAIL_CLAIM)
+                    .verify(token)
+                    .getClaim(OAUTH_ID_CLAIM)
                     .asString());
         } catch (Exception e) {
-            log.error(INVALID_ACCESS_TOKEN);
             throw new AccessTokenHandler(ErrorStatus._ACCESSTOKEN_NOT_VALID);
         }
     }
 
     /**
-     * Redis에서 RefreshToken 삭제
+     * AccessToken에서 provider(enum) 추출
      */
-    public void deleteRefreshToken(final String refreshToken) {
-        redisTemplate.delete(refreshToken);
+    public Optional<OauthServerType> extractOauthServerType(final String token) {
+        try {
+            String type = JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(token)
+                    .getClaim(PROVIDER_CLAIM)
+                    .asString();
+            return Optional.of(OauthServerType.valueOf(type));
+        } catch (Exception e) {
+            throw new AccessTokenHandler(ErrorStatus._ACCESSTOKEN_NOT_VALID);
+        }
+    }
+
+    /**
+     * JWT 유효성 검사
+     */
+    public void isTokenValid(final String token) {
+        try {
+            JWTVerifier verifier = JWT.require(Algorithm.HMAC512(secretKey)).build();
+            verifier.verify(token);
+        } catch (JWTVerificationException e) {
+            throw new TokenInvalidException("유효하지 않은 토큰");
+        } catch (Exception e) {
+            throw new RuntimeException("토큰 검증 중 런타임 오류 발생", e);
+        }
     }
 
     /**
      * Redis에 RefreshToken 저장
      */
-    public void updateRefreshToken(final String email, final String refreshToken) {
+    public void updateRefreshToken(final String oauthServerId, final OauthServerType provider, final String refreshToken) {
         RefreshToken token = RefreshToken.builder()
-                .email(email)
+                .oauthId(oauthServerId)
+                .oauthServerType(provider)
                 .refresh(refreshToken)
                 .expiration(refreshTokenExpirationPeriod)
                 .build();
+
+        String key = oauthServerId + ":" + provider.name();
+        log.info("Saving refreshToken to redis with key: {}", key);
         redisTemplate.opsForValue()
-                .set(refreshToken, token, (long) refreshTokenExpirationPeriod, TimeUnit.MILLISECONDS);
+                .set(key, token, (long) refreshTokenExpirationPeriod, TimeUnit.MILLISECONDS);
     }
 
     /**
-     * RefreshToken이 blacklist인지 확인한다
+     * RefreshToken이 blacklist인지 확인
      */
     public boolean isBlackList(final String refreshToken) {
         return redisTemplate.opsForValue().get(refreshToken) == null;
     }
 
     /**
-     * RefreshToken에서 email 가져오기
-     */
-    public String getEmailFromRefreshToken(final String refreshToken) {
-        return Optional.ofNullable((RefreshToken) redisTemplate.opsForValue().get(refreshToken))
-                .map(RefreshToken::getEmail)
-                .orElse(null);
-    }
-
-    /**
-     * 토큰 유효성 검사
-     */
-    public void isTokenValid(final String token) {
-        try {
-            JWTVerifier verifier = JWT.require(Algorithm.HMAC512(secretKey)).build();
-            DecodedJWT decodedJWT = verifier.verify(token);
-        } catch (JWTVerificationException e) {
-            throw new TokenInvalidException(INVALID_TOKEN);
-        } catch (Exception e) {
-            throw new RuntimeException(RUNTIME_ERROR_TOKEN_CHECK, e);
-        }
-    }
-
-    /**
-     * 쿠키 생성
+     * RefreshToken 쿠키 생성
      */
     private Cookie createCookie(final String key, final String value) {
         Cookie cookie = new Cookie(key, value);
@@ -235,6 +218,19 @@ public class JwtService {
         cookie.setHttpOnly(true);
         cookie.setAttribute("SameSite", "None");
         return cookie;
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        Set<String> keys = redisTemplate.keys("*:*"); // "1234567890:KAKAO" 형식
+        if (keys == null) return;
+
+        for (String key : keys) {
+            Object obj = redisTemplate.opsForValue().get(key);
+            if (obj instanceof RefreshToken token && refreshToken.equals(token.getRefresh())) {
+                redisTemplate.delete(key);
+                break;
+            }
+        }
     }
 
 }

--- a/src/main/java/com/humanicare/backend/oauth/controller/OauthController.java
+++ b/src/main/java/com/humanicare/backend/oauth/controller/OauthController.java
@@ -49,7 +49,7 @@ public class OauthController {
             @RequestParam("code") final String code,
             final HttpServletResponse response
     ) {
-        log.info("🔹 Received authCode: {}", code);
+        log.info("Received authCode: {}", code);
         User user = oauthService.login(response, oauthServerType, code);
         return ApiResponse.of(SuccessStatus.OAUTH_LOGIN, user.getRole());
     }

--- a/src/main/java/com/humanicare/backend/oauth/service/OauthService.java
+++ b/src/main/java/com/humanicare/backend/oauth/service/OauthService.java
@@ -36,12 +36,13 @@ public class OauthService {
         User user = oauthUserClientComposite.fetch(oauthServerType, authCode);
         User saved = userRepository.findByOauthId(user.getOauthId()).orElseGet(() -> userRepository.save(user));
 
-        String accessToken = jwtService.createAccessToken(user.getEmail());
+        String accessToken = jwtService.createAccessToken(saved.getOauthId().oauthServerId(), saved.getOauthId().oauthServer());
         String refreshToken = jwtService.createRefreshToken();
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
-//        jwtService.updateRefreshToken(user.getEmail(), refreshToken);
+        jwtService.updateRefreshToken(saved.getOauthId().oauthServerId(), saved.getOauthId().oauthServer(), refreshToken);
 
+        log.info("refreshToken value: {}", refreshToken);
         log.info("사용자 로그인 완료");
         return saved;
     }

--- a/src/main/java/com/humanicare/backend/repository/UserRepository.java
+++ b/src/main/java/com/humanicare/backend/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.humanicare.backend.repository;
 import com.humanicare.backend.domain.oauth.OauthId;
 import com.humanicare.backend.domain.oauth.User;
 import java.util.Optional;
+
+import com.humanicare.backend.oauth.OauthServerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,6 +12,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(final String email);
 
     Optional<User> findByOauthId(final OauthId oauthId);
+
+    Optional<User> findByOauthId_OauthServerIdAndOauthId_OauthServerType(String oauthServerId, OauthServerType oauthServerType);
+
 
     boolean existsByInvitationCode(String code);
 }

--- a/src/main/java/com/humanicare/backend/service/user/UserCheckService.java
+++ b/src/main/java/com/humanicare/backend/service/user/UserCheckService.java
@@ -4,6 +4,7 @@ import com.humanicare.backend.apiPayload.code.status.ErrorStatus;
 import com.humanicare.backend.apiPayload.exception.handler.UserHandler;
 import com.humanicare.backend.domain.oauth.User;
 import com.humanicare.backend.jwt.service.JwtService;
+import com.humanicare.backend.oauth.OauthServerType;
 import com.humanicare.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,9 @@ public class UserCheckService {
     private final UserRepository userRepository;
 
     public User getUserByToken(final String accessToken) {
-        String email = jwtService.extractEmail(accessToken).orElse(null);
-        User user = userRepository.findByEmail(email).orElse(null);
+        String oauthId = jwtService.extractOauthId(accessToken).orElse(null);
+        OauthServerType serverType = jwtService.extractOauthServerType(accessToken).orElse(null);
+        User user = userRepository.findByOauthId_OauthServerIdAndOauthId_OauthServerType(oauthId, serverType).orElse(null);
         validateUserIsNotNull(user);
         return user;
     }

--- a/src/test/java/com/humanicare/backend/jwtService/JwtServiceIntegrationTest.java
+++ b/src/test/java/com/humanicare/backend/jwtService/JwtServiceIntegrationTest.java
@@ -1,0 +1,55 @@
+package com.humanicare.backend.jwtService;
+
+import com.humanicare.backend.domain.RefreshToken;
+import com.humanicare.backend.jwt.service.JwtService;
+import com.humanicare.backend.oauth.OauthServerType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JwtServiceIntegrationTest {
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    public void createAndVerifyAccessToken_shouldExtractOauthIdAndProviderCorrectly() {
+        // given
+        String oauthId = "1234567890";
+        OauthServerType provider = OauthServerType.KAKAO;
+
+        // when
+        String token = jwtService.createAccessToken(oauthId, provider);
+
+        // then
+        assertTrue(jwtService.extractOauthId(token).isPresent());
+        assertEquals(oauthId, jwtService.extractOauthId(token).get());
+
+        assertTrue(jwtService.extractOauthServerType(token).isPresent());
+        assertEquals(provider, jwtService.extractOauthServerType(token).get());
+    }
+
+    @Test
+    public void updateRefreshToken_shouldSaveToRedisWithCorrectKey() {
+        String oauthId = "1234567890";
+        OauthServerType provider = OauthServerType.KAKAO;
+        String refreshToken = jwtService.createRefreshToken();
+
+        jwtService.updateRefreshToken(oauthId, provider, refreshToken);
+
+        String redisKey = oauthId + ":" + provider.name();
+        RefreshToken stored = (RefreshToken) redisTemplate.opsForValue().get(redisKey);
+
+        assertNotNull(stored);
+        assertEquals(refreshToken, stored.getRefresh());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> jwtService가 email을 기반으로 동작하는데 kakao의 경우 email을 2022년 이후 기본으로 제공하지 않기 때문에 OauthServer의 Id와 type을 기준으로 나누도록 바꿈.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
